### PR TITLE
enhanced unit testing

### DIFF
--- a/test/parser/cleanBill.test.js
+++ b/test/parser/cleanBill.test.js
@@ -18,6 +18,12 @@ describe('cleanBill', function() {
     }).to.throw(TypeError);
   });
 
+  it('should throw an error if the bill is an invalid object', function() {
+    expect(() => {
+      cleanBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
+    }).to.throw(Error)
+  })
+
   it('should return an object if the bill is valid', function(){
     getBill("BILLS-115hr1001ih", (res) => {
       cleanBill(res, function(cleanedRes){

--- a/test/parser/cleanBill.test.js
+++ b/test/parser/cleanBill.test.js
@@ -20,7 +20,7 @@ describe('cleanBill', function() {
 
   it('should throw an error if the bill is an invalid object', function() {
     expect(() => {
-      cleanBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
+      cleanBill({entry1: 'testing', entry2: 'error', entry3: 'handling'}, (res) => {});
     }).to.throw(Error)
   })
 

--- a/test/parser/printBill.test.js
+++ b/test/parser/printBill.test.js
@@ -3,35 +3,32 @@
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 var printBill = require("../../lib/parser/printBill.js");
-var tagBill = require("../../lib/parser/tagBill.js");
 var getBill = require("../../lib/scraper/getBill.js");
 
-describe('tagBill', function() {
+describe('printBill', function() {
   it('should throw an error if bill is not an object', function() {
     expect(() => {
-      tagBill(1, (res) => {});
+      printBill(1, (res) => {});
     }).to.throw(TypeError);
   });
 
   it('should throw an error if there is no callback', function() {
     expect(() => {
-      tagBill({});
+      printBill({});
     }).to.throw(TypeError);
   });
 
   it('should throw an error if the bill is an invalid object', function() {
     expect(() => {
-      tagBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
+      printBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
     }).to.throw(Error)
   })
 
-  it('should return an object if the bill is valid', function(){
-    getBill("BILLS-113hr1033rs", function(res){
-      printBill(res, function(parsedResult){
-        tagBill(parsedResult, function(tags){
-          expect(tags).to.be.an("object").that.is.not.empty;
-       });
-     });
-    }, {session: 2});
+  it('should return an object if the bill is valid', function() {
+    getBill("BILLS-115hr1001ih", (res) => {
+      printBill(res, function(printedRes){
+        expect(printedRes).to.be.an("object").that.is.not.empty;
+      });
+    });
   });
 });

--- a/test/parser/printBill.test.js
+++ b/test/parser/printBill.test.js
@@ -20,7 +20,7 @@ describe('printBill', function() {
 
   it('should throw an error if the bill is an invalid object', function() {
     expect(() => {
-      printBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
+      printBill({entry1: 'testing', entry2: 'error', entry3: 'handling'}, (res) => {});
     }).to.throw(Error)
   })
 

--- a/test/parser/tagBill.test.js
+++ b/test/parser/tagBill.test.js
@@ -21,7 +21,7 @@ describe('tagBill', function() {
 
   it('should throw an error if the bill is an invalid object', function() {
     expect(() => {
-      tagBill({entry1: 'testing' entry2: 'error' entry3: 'handling'}, (res) => {});
+      tagBill({entry1: 'testing', entry2: 'error', entry3: 'handling'}, (res) => {});
     }).to.throw(Error)
   })
 


### PR DESCRIPTION
Added unit tests for `printBill`.

Added additional unit test for `printBill`, `cleanBill`, and `tagBill` to ensure that the program throws an `Error` when a non-Bill JSON object is inputted as a parameter. 